### PR TITLE
fix: Update Werkzeug to 3.1.5 to fix CVE-2026-21860 and CVE-2025-66221

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -9,5 +9,5 @@ protobuf==4.25.8
 requests==2.32.4
 setuptools==78.1.1
 urllib3==2.6.3
-werkzeug==3.0.6
+werkzeug==3.1.5
 zipp==3.19.1


### PR DESCRIPTION
## Summary
- Updates Werkzeug from 3.0.6 to 3.1.5 in the trace analytics sample app
- Addresses two medium-severity (CVSS 5.3) security vulnerabilities

## Security Issues Fixed
- **CVE-2026-21860**: Werkzeug's safe_join function allows path segments with Windows device names (requires >= 3.1.5)
- **CVE-2025-66221**: Similar issue with safe_join causing files to hang when reading on Windows (requires >= 3.1.4)

## Changes
- Updated `examples/trace-analytics-sample-app/sample-app/requirements.txt`
  - `werkzeug==3.0.6` → `werkzeug==3.1.5`

## Test Plan
- [ ] Verify the sample app still functions correctly with the updated dependency
- [ ] Confirm no breaking changes in Werkzeug 3.1.5 that affect the sample app

Resolves #6326